### PR TITLE
Address dependabot issue with netlify-cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "jimp": "^1.6.0",
         "js-yaml": "^4.1.0",
         "markdownlint-cli": "^0.45.0",
-        "netlify-cli": "^23.0.0",
+        "netlify-cli": "^23.7.3",
         "prettier": "^3.6.1",
         "rimraf": "^6.0.1",
         "typescript": "~5.8.3"
@@ -15433,38 +15433,39 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/netlify-cli": {
-      "version": "23.0.0",
-      "resolved": "https://registry.npmjs.org/netlify-cli/-/netlify-cli-23.0.0.tgz",
-      "integrity": "sha512-tors9tlkZjPIV9zMg9RMVQhG/aRBXQ8+zVHibb8asqkfSibztTRVFomDFc09A2yIhRXld9TPil/BDvfqSm0ozw==",
+      "version": "23.7.3",
+      "resolved": "https://registry.npmjs.org/netlify-cli/-/netlify-cli-23.7.3.tgz",
+      "integrity": "sha512-0FD0kLjHMJNdTFbA+JXp/04ZWPI9QmEa6vy79q0CRfTgGw6a3b3dPdBL6n57eX0FGeGMcWF4SW4qceWYA9Vcrw==",
       "dev": true,
       "hasInstallScript": true,
       "hasShrinkwrap": true,
-      "license": "MIT",
       "dependencies": {
         "@fastify/static": "7.0.4",
-        "@netlify/api": "14.0.3",
-        "@netlify/blobs": "10.0.7",
-        "@netlify/build": "35.0.0",
-        "@netlify/build-info": "10.0.7",
-        "@netlify/config": "24.0.0",
-        "@netlify/dev-utils": "4.1.0",
-        "@netlify/edge-bundler": "14.2.2",
-        "@netlify/edge-functions": "2.16.2",
-        "@netlify/headers-parser": "9.0.1",
+        "@netlify/ai": "0.2.1",
+        "@netlify/api": "14.0.5",
+        "@netlify/blobs": "10.0.11",
+        "@netlify/build": "35.1.7",
+        "@netlify/build-info": "10.0.8",
+        "@netlify/config": "24.0.4",
+        "@netlify/dev-utils": "4.1.3",
+        "@netlify/edge-bundler": "14.5.5",
+        "@netlify/edge-functions": "2.17.4",
+        "@netlify/edge-functions-bootstrap": "2.14.0",
+        "@netlify/headers-parser": "9.0.2",
         "@netlify/local-functions-proxy": "2.0.3",
-        "@netlify/redirect-parser": "15.0.2",
-        "@netlify/zip-it-and-ship-it": "14.1.0",
+        "@netlify/redirect-parser": "15.0.3",
+        "@netlify/zip-it-and-ship-it": "14.1.8",
         "@octokit/rest": "21.1.1",
         "@opentelemetry/api": "1.8.0",
         "@pnpm/tabtab": "0.5.4",
-        "ansi-escapes": "7.0.0",
+        "ansi-escapes": "7.1.1",
         "ansi-to-html": "0.7.2",
         "ascii-table": "0.0.9",
         "backoff": "2.5.0",
         "boxen": "8.0.1",
-        "chalk": "5.4.1",
+        "chalk": "5.6.2",
         "chokidar": "4.0.3",
-        "ci-info": "4.2.0",
+        "ci-info": "4.3.0",
         "clean-deep": "3.4.0",
         "commander": "12.1.0",
         "comment-json": "4.2.5",
@@ -15474,7 +15475,7 @@
         "debug": "4.4.1",
         "decache": "4.6.2",
         "dot-prop": "9.0.0",
-        "dotenv": "16.6.1",
+        "dotenv": "17.2.2",
         "env-paths": "3.0.0",
         "envinfo": "7.14.0",
         "etag": "1.8.1",
@@ -15494,7 +15495,7 @@
         "http-proxy": "1.18.1",
         "http-proxy-middleware": "2.0.9",
         "https-proxy-agent": "7.0.6",
-        "inquirer": "8.2.6",
+        "inquirer": "8.2.7",
         "inquirer-autocomplete-prompt": "1.4.0",
         "ipx": "3.1.1",
         "is-docker": "3.0.0",
@@ -15514,14 +15515,14 @@
         "netlify-redirector": "0.5.0",
         "node-fetch": "3.3.2",
         "normalize-package-data": "7.0.1",
-        "open": "10.1.2",
+        "open": "10.2.0",
         "p-filter": "4.1.0",
         "p-map": "7.0.3",
         "p-wait-for": "5.0.2",
         "parallel-transform": "1.2.0",
         "parse-github-url": "1.0.3",
         "prettyjson": "1.2.5",
-        "raw-body": "3.0.0",
+        "raw-body": "3.0.1",
         "read-package-up": "11.0.0",
         "readdirp": "4.1.2",
         "semver": "7.7.2",
@@ -15593,9 +15594,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@babel/types": {
-      "version": "7.28.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
-      "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -15606,21 +15607,19 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@bugsnag/browser": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-8.2.0.tgz",
-      "integrity": "sha512-C4BfE3eVsjOAqoXbdrPXfKbgp/hz2H7mKBU0p11Jf9uz+5gUCfZK+39JLrQKvRXwqoDcTlBSfz9Xz5kXLyHg2Q==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-8.4.0.tgz",
+      "integrity": "sha512-5ZzGZtCwvhQbrMCAPAH9ruQGjVmSzjiE6qNNP2mD/8q0Yi45TWBtG/0MdlUYpDwx2lxVVHaGHqI3GBeD7B4Hqg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@bugsnag/core": "^8.2.0"
+        "@bugsnag/core": "^8.4.0"
       }
     },
     "node_modules/netlify-cli/node_modules/@bugsnag/core": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-8.2.0.tgz",
-      "integrity": "sha512-dFSs80ZwJ508nlC6UTLTUMdHgTaHY5UKvMiuHqstCQrQrOjqFcIv+x4o+l2WrSyOpoYhHAxDlKfzKN8AjwslQw==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-8.4.0.tgz",
+      "integrity": "sha512-vmGNO5gQ2qP5CE6/RzIzO2X/5oJCQGrhdUc6OwpEf4CytPidpk9LNCkscvOx9iT9Ym3USKSo7DeZhtnhFP0KKQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@bugsnag/cuid": "^3.0.0",
         "@bugsnag/safe-json-stringify": "^6.0.0",
@@ -15630,30 +15629,28 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@bugsnag/cuid": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.1.1.tgz",
-      "integrity": "sha512-d2z4b0rEo3chI07FNN1Xds8v25CNeekecU6FC/2Fs9MxY2EipkZTThVcV2YinMn8dvRUlViKOyC50evoUxg8tw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.2.1.tgz",
+      "integrity": "sha512-zpvN8xQ5rdRWakMd/BcVkdn2F8HKlDSbM3l7duueK590WmI1T0ObTLc1V/1e55r14WNjPd5AJTYX4yPEAFVi+Q==",
       "dev": true
     },
     "node_modules/netlify-cli/node_modules/@bugsnag/js": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-8.2.0.tgz",
-      "integrity": "sha512-DTtQwV1Ly5VXSOnVtzW8gSwB+ld3qIc/h0yMS836DEYUfA3V9JPwJE3+2EbD8Ea2ogkDWZ+a0jl0SNSNGiOmfA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-8.4.0.tgz",
+      "integrity": "sha512-r8M+kgNts3ebR7g9Kct2wuaipcxDEvrBwnBugJfHFRwelyysz5ZBkFAvpatSm71LyLTv/9FyvWKEVgXwV7dTBQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@bugsnag/browser": "^8.2.0",
-        "@bugsnag/node": "^8.2.0"
+        "@bugsnag/browser": "^8.4.0",
+        "@bugsnag/node": "^8.4.0"
       }
     },
     "node_modules/netlify-cli/node_modules/@bugsnag/node": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-8.2.0.tgz",
-      "integrity": "sha512-6XC/KgX61m6YFgsBQP/GaH1UzlJkJmpi3AwlZQLsXloRh3O9lM/0EIk6+2sZm+vlz+GwxCFavcuIDgVmH/qi7Q==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-8.4.0.tgz",
+      "integrity": "sha512-yqlFTvJNRwnp8jQczfgBztAhSKFc5vr9CHTUDbB72gBgCzQVQ7q16MX0tIHZVeL1Mo1Zywr9rvcPG/HBAPTuOw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@bugsnag/core": "^8.2.0",
+        "@bugsnag/core": "^8.4.0",
         "byline": "^5.0.0",
         "error-stack-parser": "^2.0.3",
         "iserror": "^0.0.2",
@@ -15749,9 +15746,9 @@
       "dev": true
     },
     "node_modules/netlify-cli/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.6.tgz",
-      "integrity": "sha512-ShbM/3XxwuxjFiuVBHA+d3j5dyac0aEVVq1oluIDf71hUw0aRF59dV/efUsIwFnR6m8JNM2FjZOzmaZ8yG61kw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
       "cpu": [
         "ppc64"
       ],
@@ -15765,9 +15762,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/android-arm": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.6.tgz",
-      "integrity": "sha512-S8ToEOVfg++AU/bHwdksHNnyLyVM+eMVAOf6yRKFitnwnbwwPNqKr3srzFRe7nzV69RQKb5DgchIX5pt3L53xg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
       "cpu": [
         "arm"
       ],
@@ -15781,9 +15778,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/android-arm64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.6.tgz",
-      "integrity": "sha512-hd5zdUarsK6strW+3Wxi5qWws+rJhCCbMiC9QZyzoxfk5uHRIE8T287giQxzVpEvCwuJ9Qjg6bEjcRJcgfLqoA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
       "cpu": [
         "arm64"
       ],
@@ -15797,9 +15794,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/android-x64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.6.tgz",
-      "integrity": "sha512-0Z7KpHSr3VBIO9A/1wcT3NTy7EB4oNC4upJ5ye3R7taCc2GUdeynSLArnon5G8scPwaU866d3H4BCrE5xLW25A==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
       "cpu": [
         "x64"
       ],
@@ -15813,9 +15810,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.6.tgz",
-      "integrity": "sha512-FFCssz3XBavjxcFxKsGy2DYK5VSvJqa6y5HXljKzhRZ87LvEi13brPrf/wdyl/BbpbMKJNOr1Sd0jtW4Ge1pAA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
       "cpu": [
         "arm64"
       ],
@@ -15829,9 +15826,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.6.tgz",
-      "integrity": "sha512-GfXs5kry/TkGM2vKqK2oyiLFygJRqKVhawu3+DOCk7OxLy/6jYkWXhlHwOoTb0WqGnWGAS7sooxbZowy+pK9Yg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
       "cpu": [
         "x64"
       ],
@@ -15845,9 +15842,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.6.tgz",
-      "integrity": "sha512-aoLF2c3OvDn2XDTRvn8hN6DRzVVpDlj2B/F66clWd/FHLiHaG3aVZjxQX2DYphA5y/evbdGvC6Us13tvyt4pWg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
       "cpu": [
         "arm64"
       ],
@@ -15861,9 +15858,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.6.tgz",
-      "integrity": "sha512-2SkqTjTSo2dYi/jzFbU9Plt1vk0+nNg8YC8rOXXea+iA3hfNJWebKYPs3xnOUf9+ZWhKAaxnQNUf2X9LOpeiMQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
       "cpu": [
         "x64"
       ],
@@ -15877,9 +15874,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/linux-arm": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.6.tgz",
-      "integrity": "sha512-SZHQlzvqv4Du5PrKE2faN0qlbsaW/3QQfUUc6yO2EjFcA83xnwm91UbEEVx4ApZ9Z5oG8Bxz4qPE+HFwtVcfyw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
       "cpu": [
         "arm"
       ],
@@ -15893,9 +15890,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.6.tgz",
-      "integrity": "sha512-b967hU0gqKd9Drsh/UuAm21Khpoh6mPBSgz8mKRq4P5mVK8bpA+hQzmm/ZwGVULSNBzKdZPQBRT3+WuVavcWsQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
       "cpu": [
         "arm64"
       ],
@@ -15909,9 +15906,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.6.tgz",
-      "integrity": "sha512-aHWdQ2AAltRkLPOsKdi3xv0mZ8fUGPdlKEjIEhxCPm5yKEThcUjHpWB1idN74lfXGnZ5SULQSgtr5Qos5B0bPw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
       "cpu": [
         "ia32"
       ],
@@ -15925,9 +15922,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.6.tgz",
-      "integrity": "sha512-VgKCsHdXRSQ7E1+QXGdRPlQ/e08bN6WMQb27/TMfV+vPjjTImuT9PmLXupRlC90S1JeNNW5lzkAEO/McKeJ2yg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
       "cpu": [
         "loong64"
       ],
@@ -15941,9 +15938,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.6.tgz",
-      "integrity": "sha512-WViNlpivRKT9/py3kCmkHnn44GkGXVdXfdc4drNmRl15zVQ2+D2uFwdlGh6IuK5AAnGTo2qPB1Djppj+t78rzw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
       "cpu": [
         "mips64el"
       ],
@@ -15957,9 +15954,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.6.tgz",
-      "integrity": "sha512-wyYKZ9NTdmAMb5730I38lBqVu6cKl4ZfYXIs31Baf8aoOtB4xSGi3THmDYt4BTFHk7/EcVixkOV2uZfwU3Q2Jw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
       "cpu": [
         "ppc64"
       ],
@@ -15973,9 +15970,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.6.tgz",
-      "integrity": "sha512-KZh7bAGGcrinEj4qzilJ4hqTY3Dg2U82c8bv+e1xqNqZCrCyc+TL9AUEn5WGKDzm3CfC5RODE/qc96OcbIe33w==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
       "cpu": [
         "riscv64"
       ],
@@ -15989,9 +15986,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.6.tgz",
-      "integrity": "sha512-9N1LsTwAuE9oj6lHMyyAM+ucxGiVnEqUdp4v7IaMmrwb06ZTEVCIs3oPPplVsnjPfyjmxwHxHMF8b6vzUVAUGw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
       "cpu": [
         "s390x"
       ],
@@ -16005,9 +16002,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/linux-x64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.6.tgz",
-      "integrity": "sha512-A6bJB41b4lKFWRKNrWoP2LHsjVzNiaurf7wyj/XtFNTsnPuxwEBWHLty+ZE0dWBKuSK1fvKgrKaNjBS7qbFKig==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
       "cpu": [
         "x64"
       ],
@@ -16021,9 +16018,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.6.tgz",
-      "integrity": "sha512-IjA+DcwoVpjEvyxZddDqBY+uJ2Snc6duLpjmkXm/v4xuS3H+3FkLZlDm9ZsAbF9rsfP3zeA0/ArNDORZgrxR/Q==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
       "cpu": [
         "arm64"
       ],
@@ -16037,9 +16034,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.6.tgz",
-      "integrity": "sha512-dUXuZr5WenIDlMHdMkvDc1FAu4xdWixTCRgP7RQLBOkkGgwuuzaGSYcOpW4jFxzpzL1ejb8yF620UxAqnBrR9g==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
       "cpu": [
         "x64"
       ],
@@ -16053,9 +16050,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.6.tgz",
-      "integrity": "sha512-l8ZCvXP0tbTJ3iaqdNf3pjaOSd5ex/e6/omLIQCVBLmHTlfXW3zAxQ4fnDmPLOB1x9xrcSi/xtCWFwCZRIaEwg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
       "cpu": [
         "arm64"
       ],
@@ -16069,9 +16066,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.6.tgz",
-      "integrity": "sha512-hKrmDa0aOFOr71KQ/19JC7az1P0GWtCN1t2ahYAf4O007DHZt/dW8ym5+CUdJhQ/qkZmI1HAF8KkJbEFtCL7gw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
       "cpu": [
         "x64"
       ],
@@ -16085,9 +16082,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.6.tgz",
-      "integrity": "sha512-+SqBcAWoB1fYKmpWoQP4pGtx+pUUC//RNYhFdbcSA16617cchuryuhOCRpPsjCblKukAckWsV+aQ3UKT/RMPcA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
       "cpu": [
         "arm64"
       ],
@@ -16101,9 +16098,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.6.tgz",
-      "integrity": "sha512-dyCGxv1/Br7MiSC42qinGL8KkG4kX0pEsdb0+TKhmJZgCUDBGmyo1/ArCjNGiOLiIAgdbWgmWgib4HoCi5t7kA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
       "cpu": [
         "x64"
       ],
@@ -16117,9 +16114,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.6.tgz",
-      "integrity": "sha512-42QOgcZeZOvXfsCBJF5Afw73t4veOId//XD3i+/9gSkhSV6Gk3VPlWncctI+JcOyERv85FUo7RxuxGy+z8A43Q==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
       "cpu": [
         "arm64"
       ],
@@ -16133,9 +16130,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.6.tgz",
-      "integrity": "sha512-4AWhgXmDuYN7rJI6ORB+uU9DHLq/erBbuMoAuB4VWJTu5KtCgcKYPynF0YI1VkBNuEfjNlLrFr9KZPJzrtLkrQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
       "cpu": [
         "ia32"
       ],
@@ -16149,9 +16146,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@esbuild/win32-x64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.6.tgz",
-      "integrity": "sha512-NgJPHHbEpLQgDH2MjQu90pzW/5vvXIZ7KOnPyNBm92A6WgZ/7b6fJyUBjoumLqeOQQGqY2QjQxRo97ah4Sj0cA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
       "cpu": [
         "x64"
       ],
@@ -16395,6 +16392,41 @@
       "integrity": "sha512-RwzRTpmrrS6Q1ZhQExwuxJGK1Wqhv4stt+OF2JzS+uawewpwNyU7EJL1WpBex7aDiiGLs4FsXGkfUBdYuX7xiQ==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@inquirer/external-editor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.1.tgz",
+      "integrity": "sha512-Oau4yL24d2B5IL4ma4UpbQigkVhzPDXLoqy1ggK4gnHg/stmkffJE4oOXHXF3uz0UEpywG68KcyXsyYpA1Re/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.0",
+        "iconv-lite": "^0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/netlify-cli/node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -16474,11 +16506,10 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
     },
     "node_modules/netlify-cli/node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
@@ -16540,19 +16571,31 @@
         }
       }
     },
-    "node_modules/netlify-cli/node_modules/@netlify/api": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@netlify/api/-/api-14.0.3.tgz",
-      "integrity": "sha512-iFYqSYBnn34Fx3eVOH7sG52f/xcyB9or2yjn486d3ZqLk6OJGFZstxjY4LfTv8chCT1HeSVybIvnCqsHsvrzJQ==",
+    "node_modules/netlify-cli/node_modules/@netlify/ai": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@netlify/ai/-/ai-0.2.1.tgz",
+      "integrity": "sha512-pc30UjYtmoP9XyY6b+xyD/Xh3RYtuc3VcboKU0Ojdv3fX27NUEy3ZLYlmhHB+8E1zVHhyHsoBHqTt/He/YuhXw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@netlify/open-api": "^2.37.0",
-        "lodash-es": "^4.17.21",
-        "micro-api-client": "^3.3.0",
+        "@netlify/api": "^14.0.4"
+      },
+      "engines": {
+        "node": ">=20.6.1"
+      },
+      "peerDependencies": {
+        "@netlify/api": ">=14.0.0"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@netlify/api": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/@netlify/api/-/api-14.0.5.tgz",
+      "integrity": "sha512-EPJ35sULvkL7nmJ3tpE7M1xsOrf1i/iN7iLBogC295x8uJqkXmcKEg5GIcb6Le3FKy0nno/dIhCZsSfL5tlEyw==",
+      "dev": true,
+      "dependencies": {
+        "@netlify/open-api": "^2.38.0",
         "node-fetch": "^3.0.0",
         "p-wait-for": "^5.0.0",
-        "qs": "^6.9.6"
+        "picoquery": "^2.5.0"
       },
       "engines": {
         "node": ">=18.14.0"
@@ -16565,37 +16608,61 @@
       "dev": true
     },
     "node_modules/netlify-cli/node_modules/@netlify/blobs": {
-      "version": "10.0.7",
-      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-10.0.7.tgz",
-      "integrity": "sha512-kvkq04TLRNkEwBOwoLwnfw9Bud8KF5HjHNgCuQVNkkHL9f1S/MZDdiKgpbs/fKo6fSNctxOzHUVCN3jFEvmVZg==",
+      "version": "10.0.11",
+      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-10.0.11.tgz",
+      "integrity": "sha512-/pa7eD2gxkhJ6aUIJULrRu3tvAaimy+sA6vHUuGRMvncjOuRpeatXLHxuzdn8DyK1CZCjN3E33oXsdEpoqG7SA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@netlify/dev-utils": "4.1.0",
+        "@netlify/dev-utils": "4.2.0",
         "@netlify/runtime-utils": "2.1.0"
       },
       "engines": {
         "node": "^14.16.0 || >=16.0.0"
       }
     },
-    "node_modules/netlify-cli/node_modules/@netlify/build": {
-      "version": "35.0.0",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-35.0.0.tgz",
-      "integrity": "sha512-mFl2WKefjinzOnQoZ5osZPNH7Qw6/iqDcKFenTbDJ5x2clQqGB3DClp5AyKvsxkN1/bdHwe/OHV3lS7+CYLk0Q==",
+    "node_modules/netlify-cli/node_modules/@netlify/blobs/node_modules/@netlify/dev-utils": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@netlify/dev-utils/-/dev-utils-4.2.0.tgz",
+      "integrity": "sha512-P/uLJ5IKB4DhUOd6Q4Mpk7N0YKrnijUhAL3C05dEftNi3U3xJB98YekYfsL3G6GkS3L35pKGMx+vKJRwUHpP1Q==",
       "dev": true,
-      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/server": "^0.10.0",
+        "ansis": "^4.1.0",
+        "chokidar": "^4.0.1",
+        "decache": "^4.6.2",
+        "dettle": "^1.0.5",
+        "dot-prop": "9.0.0",
+        "empathic": "^2.0.0",
+        "env-paths": "^3.0.0",
+        "image-size": "^2.0.2",
+        "js-image-generator": "^1.0.4",
+        "parse-gitignore": "^2.0.0",
+        "semver": "^7.7.2",
+        "tmp-promise": "^3.0.3",
+        "uuid": "^11.1.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || >=20"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@netlify/build": {
+      "version": "35.1.7",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-35.1.7.tgz",
+      "integrity": "sha512-ijWgogK6sQaVqr4OCUS8RUAkBqg4pi/h1NlzIBudBk0+emt7+VPYutgKoNuRqfnweWSw2N4eGaP/xBiSfCDj2w==",
+      "dev": true,
       "dependencies": {
         "@bugsnag/js": "^8.0.0",
-        "@netlify/blobs": "^10.0.7",
-        "@netlify/cache-utils": "^6.0.3",
-        "@netlify/config": "^24.0.0",
-        "@netlify/edge-bundler": "14.2.2",
-        "@netlify/functions-utils": "^6.2.0",
+        "@netlify/blobs": "^10.0.11",
+        "@netlify/cache-utils": "^6.0.4",
+        "@netlify/config": "^24.0.4",
+        "@netlify/edge-bundler": "14.5.5",
+        "@netlify/functions-utils": "^6.2.8",
         "@netlify/git-utils": "^6.0.2",
         "@netlify/opentelemetry-utils": "^2.0.1",
         "@netlify/plugins-list": "^6.80.0",
         "@netlify/run-utils": "^6.0.2",
-        "@netlify/zip-it-and-ship-it": "14.1.0",
+        "@netlify/zip-it-and-ship-it": "14.1.8",
         "@sindresorhus/slugify": "^2.0.0",
         "ansi-escapes": "^7.0.0",
         "ansis": "^4.1.0",
@@ -16608,21 +16675,17 @@
         "indent-string": "^5.0.0",
         "is-plain-obj": "^4.0.0",
         "keep-func-props": "^6.0.0",
-        "locate-path": "^7.0.0",
         "log-process-errors": "^11.0.0",
-        "map-obj": "^5.0.0",
         "memoize-one": "^6.0.0",
         "minimatch": "^9.0.4",
         "os-name": "^6.0.0",
         "p-event": "^6.0.0",
-        "p-every": "^2.0.0",
         "p-filter": "^4.0.0",
         "p-locate": "^6.0.0",
         "p-map": "^7.0.0",
         "p-reduce": "^3.0.0",
         "package-directory": "^8.0.0",
         "path-exists": "^5.0.0",
-        "path-type": "^6.0.0",
         "pretty-ms": "^9.0.0",
         "ps-list": "^8.0.0",
         "read-package-up": "^11.0.0",
@@ -16632,14 +16695,14 @@
         "safe-json-stringify": "^1.2.0",
         "semver": "^7.3.8",
         "string-width": "^7.0.0",
-        "strip-ansi": "^7.0.0",
         "supports-color": "^10.0.0",
         "terminal-link": "^4.0.0",
         "ts-node": "^10.9.1",
         "typescript": "^5.0.0",
         "uuid": "^11.0.0",
         "yaml": "^2.8.0",
-        "yargs": "^17.6.0"
+        "yargs": "^17.6.0",
+        "zod": "^3.25.76"
       },
       "bin": {
         "netlify-build": "bin.js"
@@ -16658,11 +16721,10 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/build-info": {
-      "version": "10.0.7",
-      "resolved": "https://registry.npmjs.org/@netlify/build-info/-/build-info-10.0.7.tgz",
-      "integrity": "sha512-RZmSg0wekEUtPklRR8z6rsG5TPXRfT2EnamDBp94ZTUixDxDk07UCMBiz2hMKMg3qA6KTW6csuFNruvD3jw5Kw==",
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@netlify/build-info/-/build-info-10.0.8.tgz",
+      "integrity": "sha512-IotJn/+dizJpWIOJcSHiSFpIPpB0b2+s11Y0OekY3XFr58Wt3UGjbCNdO0cG4i3gsQEjzM2+lDQYgJ85TqPmSw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@bugsnag/js": "^8.0.0",
         "@iarna/toml": "^2.2.5",
@@ -16715,9 +16777,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/build/node_modules/emoji-regex": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
       "dev": true
     },
     "node_modules/netlify-cli/node_modules/@netlify/build/node_modules/execa": {
@@ -16929,9 +16991,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/cache-utils": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@netlify/cache-utils/-/cache-utils-6.0.3.tgz",
-      "integrity": "sha512-NGkTvsVWs8gbd/wKOQnGjjxtaeTS+2UbqF/eZ5A/hFCXMNWf6xMQ7BcBM+pWLojHJWg/o8P1VgCZ1FDa8Zni4w==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@netlify/cache-utils/-/cache-utils-6.0.4.tgz",
+      "integrity": "sha512-KD6IXLbJcjJ5BhjGCy32BJtp1WxvTBS9J5cvdxjbBJGgfLWuJwzUzU8LR2sA4fppCCnEdKJdKy40OcVGZE0iUg==",
       "dev": true,
       "dependencies": {
         "cpy": "^11.0.0",
@@ -16940,7 +17002,6 @@
         "junk": "^4.0.0",
         "locate-path": "^7.0.0",
         "move-file": "^3.0.0",
-        "path-exists": "^5.0.0",
         "readdirp": "^4.0.0"
       },
       "engines": {
@@ -16963,26 +17024,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/netlify-cli/node_modules/@netlify/cache-utils/node_modules/path-exists": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
     "node_modules/netlify-cli/node_modules/@netlify/config": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-24.0.0.tgz",
-      "integrity": "sha512-g54OUVw8YEoIQFLx4gZPUl3225UUJUZFplGg92aoZS1Zkt3SLLa9lV1VUX43NPvC9i19R2UPTetl57hWryqiEA==",
+      "version": "24.0.4",
+      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-24.0.4.tgz",
+      "integrity": "sha512-u5RyiCN5Fu165qMBpaQEP7fvnjWzcWwnZ6e+h9obQmNtTF5XPMiaxTITT9Qotsqw1Tz9I486I+nbqwDSE/Dp7g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
-        "@netlify/api": "^14.0.3",
-        "@netlify/headers-parser": "^9.0.1",
-        "@netlify/redirect-parser": "^15.0.2",
+        "@netlify/api": "^14.0.5",
+        "@netlify/headers-parser": "^9.0.2",
+        "@netlify/redirect-parser": "^15.0.3",
         "chalk": "^5.0.0",
         "cron-parser": "^4.1.0",
         "deepmerge": "^4.2.2",
@@ -17017,7 +17068,6 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
       "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^8.0.1",
@@ -17041,7 +17091,6 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
       "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=16"
       },
@@ -17054,7 +17103,6 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
       "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=16.17.0"
       }
@@ -17064,7 +17112,6 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
       "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -17077,7 +17124,6 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
       "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "path-key": "^4.0.0"
       },
@@ -17093,7 +17139,6 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
       "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "mimic-fn": "^4.0.0"
       },
@@ -17109,7 +17154,6 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
       "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^1.0.0"
       },
@@ -17125,7 +17169,6 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
       "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "p-limit": "^4.0.0"
       },
@@ -17141,7 +17184,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">=14"
       },
@@ -17154,7 +17196,6 @@
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
       "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -17167,7 +17208,6 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
       "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12.20"
       },
@@ -17176,31 +17216,30 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/config/node_modules/zod": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.10.tgz",
-      "integrity": "sha512-3vB+UU3/VmLL2lvwcY/4RV2i9z/YU0DTV/tDuYjrwmx5WeJ7hwy+rGEEx8glHp6Yxw7ibRbKSaIFBgReRPe5KA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/dev-utils": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@netlify/dev-utils/-/dev-utils-4.1.0.tgz",
-      "integrity": "sha512-ftDT7G2IKCwcjULat/I5fbWwqgXhcJ1Vw7Xmda23qNLYhL9YxHn1FvIe10oHZuR/0ZHIUULuvOmswLdeoC6hqQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@netlify/dev-utils/-/dev-utils-4.1.3.tgz",
+      "integrity": "sha512-Cc8XNyKNVPWmRJAMVD8VICdYvVxZ66uoVdDzSyhrctw0cT7hW3NAlXF/xoLFK7uOV1xejah/Qt+2MPCJn32mqg==",
       "dev": true,
       "dependencies": {
         "@whatwg-node/server": "^0.10.0",
         "ansis": "^4.1.0",
         "chokidar": "^4.0.1",
         "decache": "^4.6.2",
+        "dettle": "^1.0.5",
         "dot-prop": "9.0.0",
+        "empathic": "^2.0.0",
         "env-paths": "^3.0.0",
-        "find-up": "7.0.0",
         "image-size": "^2.0.2",
         "js-image-generator": "^1.0.4",
-        "lodash.debounce": "^4.0.8",
         "parse-gitignore": "^2.0.0",
         "semver": "^7.7.2",
         "tmp-promise": "^3.0.3",
@@ -17212,9 +17251,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/edge-bundler": {
-      "version": "14.2.2",
-      "resolved": "https://registry.npmjs.org/@netlify/edge-bundler/-/edge-bundler-14.2.2.tgz",
-      "integrity": "sha512-APXlNsMioyd1AMECuWkkxJ6eoASYwXs8T8149IuM65KhQMR40OsPpcgt/ceg/0GydXceymHqZnkNwbapqgnvOg==",
+      "version": "14.5.5",
+      "resolved": "https://registry.npmjs.org/@netlify/edge-bundler/-/edge-bundler-14.5.5.tgz",
+      "integrity": "sha512-jf/8EYJVG/8F7w8QKgxNcIGPNAZdA90K6VwxXBGfBpp23mP4oqKHrBqivgPTWnbl4wHUPEEusT7UkONf3Yh1WQ==",
       "dev": true,
       "dependencies": {
         "@import-maps/resolve": "^2.0.0",
@@ -17223,18 +17262,17 @@
         "better-ajv-errors": "^1.2.0",
         "common-path-prefix": "^3.0.0",
         "env-paths": "^3.0.0",
-        "esbuild": "0.25.6",
+        "esbuild": "0.25.10",
         "execa": "^8.0.0",
         "find-up": "^7.0.0",
-        "get-package-name": "^2.2.0",
         "get-port": "^7.0.0",
-        "is-path-inside": "^4.0.0",
         "node-stream-zip": "^1.15.0",
         "p-retry": "^6.0.0",
         "p-wait-for": "^5.0.0",
         "parse-imports": "^2.2.1",
         "path-key": "^4.0.0",
         "semver": "^7.3.8",
+        "tar": "^7.4.3",
         "tmp-promise": "^3.0.3",
         "urlpattern-polyfill": "8.0.2",
         "uuid": "^11.0.0"
@@ -17292,9 +17330,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/edge-bundler/node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
       "dev": true,
       "funding": [
         {
@@ -17413,16 +17451,16 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/edge-functions": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/@netlify/edge-functions/-/edge-functions-2.16.2.tgz",
-      "integrity": "sha512-vpNT/VrfvymLx9MH46cuvTfPfEVZtpkwdM5atApzWLUrbyA0pgooAx2H0jupJk+u8yTfEYZCMvtsENEZO82agw==",
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/@netlify/edge-functions/-/edge-functions-2.17.4.tgz",
+      "integrity": "sha512-r8cmsTxlF7TUAmVCplS14H+HQewhfqKaCiVshAr4rlSdCfH1QqygMPWFAxgWNhLcgFQOVYH1+uT0fUZOTlVoiA==",
       "dev": true,
       "dependencies": {
-        "@netlify/dev-utils": "4.1.0",
-        "@netlify/edge-bundler": "^14.2.2",
-        "@netlify/edge-functions-bootstrap": "^2.14.0",
+        "@netlify/dev-utils": "4.1.3",
+        "@netlify/edge-bundler": "^14.5.2",
+        "@netlify/edge-functions-bootstrap": "^2.16.0",
         "@netlify/runtime-utils": "2.1.0",
-        "@netlify/types": "2.0.2",
+        "@netlify/types": "2.0.3",
         "get-port": "^7.1.0"
       },
       "engines": {
@@ -17433,6 +17471,39 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/@netlify/edge-functions-bootstrap/-/edge-functions-bootstrap-2.14.0.tgz",
       "integrity": "sha512-Fs1cQ+XKfKr2OxrAvmX+S46CJmrysxBdCUCTk/wwcCZikrDvsYUFG7FTquUl4JfAf9taYYyW/tPv35gKOKS8BQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/netlify-cli/node_modules/@netlify/edge-functions/node_modules/@netlify/dev-utils": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@netlify/dev-utils/-/dev-utils-4.1.3.tgz",
+      "integrity": "sha512-Cc8XNyKNVPWmRJAMVD8VICdYvVxZ66uoVdDzSyhrctw0cT7hW3NAlXF/xoLFK7uOV1xejah/Qt+2MPCJn32mqg==",
+      "dev": true,
+      "dependencies": {
+        "@whatwg-node/server": "^0.10.0",
+        "ansis": "^4.1.0",
+        "chokidar": "^4.0.1",
+        "decache": "^4.6.2",
+        "dettle": "^1.0.5",
+        "dot-prop": "9.0.0",
+        "empathic": "^2.0.0",
+        "env-paths": "^3.0.0",
+        "image-size": "^2.0.2",
+        "js-image-generator": "^1.0.4",
+        "parse-gitignore": "^2.0.0",
+        "semver": "^7.7.2",
+        "tmp-promise": "^3.0.3",
+        "uuid": "^11.1.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || >=20"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@netlify/edge-functions/node_modules/@netlify/edge-functions-bootstrap": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/@netlify/edge-functions-bootstrap/-/edge-functions-bootstrap-2.16.3.tgz",
+      "integrity": "sha512-ae/bJpeAnHZK8ailEKfcV4smmkbCAORpVyU3WgYJwvKp94NOXzo+OWQZbCNIbcEMq2q7luRdmu1KeREh4D5Qgg==",
       "dev": true
     },
     "node_modules/netlify-cli/node_modules/@netlify/edge-functions/node_modules/get-port": {
@@ -17448,12 +17519,12 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/functions-utils": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@netlify/functions-utils/-/functions-utils-6.2.0.tgz",
-      "integrity": "sha512-GCLjWKulGfDh7tfR28tz5lRoVBOQZL4SNac4XijCzZ2Sg93LfNUKSI9q+8yWEy5/wjNOEVp9nhZmrLoTtWpTdQ==",
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/@netlify/functions-utils/-/functions-utils-6.2.8.tgz",
+      "integrity": "sha512-RkvLcfa8Q4Ff19Qgzhfb0ORDL3PZXI5WJfMwEjjjSOW3HKPRrd+JTOEO+fgkScuzkMhG/DzvvTUs/JRpjWZmXw==",
       "dev": true,
       "dependencies": {
-        "@netlify/zip-it-and-ship-it": "14.1.0",
+        "@netlify/zip-it-and-ship-it": "14.1.8",
         "cpy": "^11.0.0",
         "path-exists": "^5.0.0"
       },
@@ -17607,11 +17678,10 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/headers-parser": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@netlify/headers-parser/-/headers-parser-9.0.1.tgz",
-      "integrity": "sha512-KHKNVNtzWUkUQhttHsLA217xIjUQxBOY5RCMRkR77G5pH1Sca9gqGhnMvk3KfRol/OZK2/1k83ZpYuvMswsK/w==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@netlify/headers-parser/-/headers-parser-9.0.2.tgz",
+      "integrity": "sha512-86YEGPxVemhksY1LeSr8NSOyH11RHvYHq+FuBJnTlPZoRDX+TD+0TAxF6lwzAgVTd1VPkyFEHlNgUGqw7aNzRQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
         "escape-string-regexp": "^5.0.0",
@@ -17862,9 +17932,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/open-api": {
-      "version": "2.37.0",
-      "resolved": "https://registry.npmjs.org/@netlify/open-api/-/open-api-2.37.0.tgz",
-      "integrity": "sha512-zXnRFkxgNsalSgU8/vwTWnav3R+8KG8SsqHxqaoJdjjJtnZR7wo3f+qqu4z+WtZ/4V7fly91HFUwZ6Uz2OdW7w==",
+      "version": "2.38.0",
+      "resolved": "https://registry.npmjs.org/@netlify/open-api/-/open-api-2.38.0.tgz",
+      "integrity": "sha512-CiTfXV226itvGRzFCNCwegblJd9fUl+ZgrI6/9JEDH6b11uI0y+gZnk+eT8onOias/rq0ep0DCwIElG6vMbCTw==",
       "dev": true,
       "engines": {
         "node": ">=14.8.0"
@@ -17892,15 +17962,13 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/redirect-parser": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@netlify/redirect-parser/-/redirect-parser-15.0.2.tgz",
-      "integrity": "sha512-zS6qBHpmU7IpHGzrHNPqu+Tjvh1cAJuVEoFUvCp0lRUeNcTdIq9VZM7/34vtIN6MD/OMFg3uv80yefSqInV2nA==",
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@netlify/redirect-parser/-/redirect-parser-15.0.3.tgz",
+      "integrity": "sha512-/HB3fcRRNgf6O/pbLn4EYNDHrU2kiadMMnazg8/OjvQK2S9i4y61vQcrICvDxYKUKQdgeEaABUuaCNAJFnfD9w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
         "fast-safe-stringify": "^2.1.1",
-        "filter-obj": "^6.0.0",
         "is-plain-obj": "^4.0.0",
         "path-exists": "^5.0.0"
       },
@@ -18049,36 +18117,34 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/types": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@netlify/types/-/types-2.0.2.tgz",
-      "integrity": "sha512-6899BAqehToSAd3hoevqGaIkG0M9epPMLTi6byynNVIzqv2x+b9OtRXqK67G/gCX7XkrtLQ9Xm3QNJmaFNrSXA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@netlify/types/-/types-2.0.3.tgz",
+      "integrity": "sha512-OcV8ivKTdsyANqVSQzbusOA7FVtE9s6zwxNCGR/aNnQaVxMUgm93UzKgfR7cZ1nnQNZHAbjd0dKJKaAUqrzbMw==",
       "dev": true,
       "engines": {
         "node": "^18.14.0 || >=20"
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/zip-it-and-ship-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-14.1.0.tgz",
-      "integrity": "sha512-avFOrCOoRMCHfeZyVUNBAbP4Byi0FMYSWS2j4zn5KAbpBgOFRRc841JnGlXGB5gCIzsrJAsW5ZL8SnlXf6lrOQ==",
+      "version": "14.1.8",
+      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-14.1.8.tgz",
+      "integrity": "sha512-APPNgGUAb1kSe4e9KxhRAeQIPGx8EAfwZ3S61eGyZXXGXgjnKmC2Ho7jsFnLsElbt8Ailyzmi/wAjh0NHZjGjA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.22.5",
-        "@babel/types": "7.28.1",
+        "@babel/types": "7.28.4",
         "@netlify/binary-info": "^1.0.0",
-        "@netlify/serverless-functions-api": "^2.1.3",
+        "@netlify/serverless-functions-api": "^2.5.0",
         "@vercel/nft": "0.29.4",
         "archiver": "^7.0.0",
         "common-path-prefix": "^3.0.0",
         "copy-file": "^11.0.0",
         "es-module-lexer": "^1.0.0",
-        "esbuild": "0.25.6",
+        "esbuild": "0.25.10",
         "execa": "^8.0.0",
         "fast-glob": "^3.3.3",
         "filter-obj": "^6.0.0",
         "find-up": "^7.0.0",
-        "is-builtin-module": "^3.1.0",
         "is-path-inside": "^4.0.0",
         "junk": "^4.0.0",
         "locate-path": "^7.0.0",
@@ -18106,9 +18172,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/zip-it-and-ship-it/node_modules/@netlify/serverless-functions-api": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@netlify/serverless-functions-api/-/serverless-functions-api-2.1.3.tgz",
-      "integrity": "sha512-bNlN/hpND8xFQzpjyKxm6vJayD+bPBlOvs4lWihE7WULrphuH1UuFsoVE5386bNNGH8Rs1IH01AFsl7ALQgOlQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@netlify/serverless-functions-api/-/serverless-functions-api-2.5.0.tgz",
+      "integrity": "sha512-0Hl6POpkEs3aan8T+EQvPIj5/gNc+64nwNv93VY4JoxFSrLPKYWmUyXJhT9lG93VxwGfmbxrCOV8U4sq2eWgTw==",
       "dev": true,
       "engines": {
         "node": ">=18.0.0"
@@ -18868,9 +18934,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@rollup/pluginutils": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
-      "integrity": "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
       "dev": true,
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -19398,12 +19464,12 @@
       "peer": true
     },
     "node_modules/netlify-cli/node_modules/@types/node": {
-      "version": "18.19.120",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.120.tgz",
-      "integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
+      "version": "22.17.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.2.tgz",
+      "integrity": "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==",
       "dev": true,
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/netlify-cli/node_modules/@types/normalize-package-data": {
@@ -19993,9 +20059,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -20113,9 +20179,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/ansi-escapes": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
-      "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.1.1.tgz",
+      "integrity": "sha512-Zhl0ErHcSRUaVfGUeUdDuLgpkEo8KIFjB4Y9uAc46ScOpdDiU1Dbyplh7qWJeJ/ZHpbyMSM26+X3BySgnIz40Q==",
       "dev": true,
       "dependencies": {
         "environment": "^1.0.0"
@@ -20876,18 +20942,6 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
-    "node_modules/netlify-cli/node_modules/builtin-modules": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
-      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/netlify-cli/node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -20987,9 +21041,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -20999,10 +21053,11 @@
       }
     },
     "node_modules/netlify-cli/node_modules/chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
+      "integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/netlify-cli/node_modules/chokidar": {
       "version": "4.0.3",
@@ -21029,9 +21084,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/ci-info": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.2.0.tgz",
-      "integrity": "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
+      "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
       "dev": true,
       "funding": [
         {
@@ -21039,7 +21094,6 @@
           "url": "https://github.com/sponsors/sibiraj-s"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -22184,6 +22238,12 @@
         "typescript": "^5.4.4"
       }
     },
+    "node_modules/netlify-cli/node_modules/dettle": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/dettle/-/dettle-1.0.5.tgz",
+      "integrity": "sha512-ZVyjhAJ7sCe1PNXEGveObOH9AC8QvMga3HJIghHawtG7mE4K5pW9nz/vDGAr/U7a3LWgdOzEE7ac9MURnyfaTA==",
+      "dev": true
+    },
     "node_modules/netlify-cli/node_modules/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -22277,9 +22337,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -22328,6 +22388,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/empathic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
+      "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/netlify-cli/node_modules/enabled": {
       "version": "2.0.0",
@@ -22472,9 +22541,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/esbuild": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.6.tgz",
-      "integrity": "sha512-GVuzuUwtdsghE3ocJ9Bs8PNoF13HNQ5TXbEi2AhvVb8xU1Iwt9Fos9FEamfoee+u/TOsn7GUWc04lz46n2bbTg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -22484,32 +22553,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.6",
-        "@esbuild/android-arm": "0.25.6",
-        "@esbuild/android-arm64": "0.25.6",
-        "@esbuild/android-x64": "0.25.6",
-        "@esbuild/darwin-arm64": "0.25.6",
-        "@esbuild/darwin-x64": "0.25.6",
-        "@esbuild/freebsd-arm64": "0.25.6",
-        "@esbuild/freebsd-x64": "0.25.6",
-        "@esbuild/linux-arm": "0.25.6",
-        "@esbuild/linux-arm64": "0.25.6",
-        "@esbuild/linux-ia32": "0.25.6",
-        "@esbuild/linux-loong64": "0.25.6",
-        "@esbuild/linux-mips64el": "0.25.6",
-        "@esbuild/linux-ppc64": "0.25.6",
-        "@esbuild/linux-riscv64": "0.25.6",
-        "@esbuild/linux-s390x": "0.25.6",
-        "@esbuild/linux-x64": "0.25.6",
-        "@esbuild/netbsd-arm64": "0.25.6",
-        "@esbuild/netbsd-x64": "0.25.6",
-        "@esbuild/openbsd-arm64": "0.25.6",
-        "@esbuild/openbsd-x64": "0.25.6",
-        "@esbuild/openharmony-arm64": "0.25.6",
-        "@esbuild/sunos-x64": "0.25.6",
-        "@esbuild/win32-arm64": "0.25.6",
-        "@esbuild/win32-ia32": "0.25.6",
-        "@esbuild/win32-x64": "0.25.6"
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
       }
     },
     "node_modules/netlify-cli/node_modules/escalade": {
@@ -22820,20 +22889,6 @@
       "dependencies": {
         "ext-list": "^2.0.0",
         "sort-keys-length": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dev": true,
-      "dependencies": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
       },
       "engines": {
         "node": ">=4"
@@ -23511,16 +23566,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/netlify-cli/node_modules/get-package-name": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/get-package-name/-/get-package-name-2.2.0.tgz",
-      "integrity": "sha512-LmCKVxioe63Fy6KDAQ/mmCSOSSRUE/x4zdrMD+7dU8quF3bGpzvP8mOmq4Dgce3nzU9AgkVDotucNOOg7c27BQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
     "node_modules/netlify-cli/node_modules/get-port": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
@@ -23778,18 +23823,17 @@
       "dev": true
     },
     "node_modules/netlify-cli/node_modules/h3": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.3.tgz",
-      "integrity": "sha512-z6GknHqyX0h9aQaTx22VZDf6QyZn+0Nh+Ym8O/u0SGSkyF5cuTJYKlc8MkzW3Nzf9LE1ivcpmYC3FUGpywhuUQ==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.4.tgz",
+      "integrity": "sha512-z5cFQWDffyOe4vQ9xIqNfCZdV4p//vy6fBnr8Q1AWnVZ0teurKMG66rLj++TKwKPUP3u7iMUvrvKaEUiQw2QWQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cookie-es": "^1.2.2",
-        "crossws": "^0.3.4",
+        "crossws": "^0.3.5",
         "defu": "^6.1.4",
         "destr": "^2.0.5",
         "iron-webcrypto": "^1.2.1",
-        "node-mock-http": "^1.0.0",
+        "node-mock-http": "^1.0.2",
         "radix3": "^1.1.2",
         "ufo": "^1.6.1",
         "uncrypto": "^0.1.3"
@@ -23874,9 +23918,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/http-cache-semantics": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "dev": true
     },
     "node_modules/netlify-cli/node_modules/http-errors": {
@@ -24107,16 +24151,17 @@
       "dev": true
     },
     "node_modules/netlify-cli/node_modules/inquirer": {
-      "version": "8.2.6",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
-      "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
+      "version": "8.2.7",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.7.tgz",
+      "integrity": "sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
+        "@inquirer/external-editor": "^1.0.0",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.1",
         "cli-cursor": "^3.1.0",
         "cli-width": "^3.0.0",
-        "external-editor": "^3.0.3",
         "figures": "^3.0.0",
         "lodash": "^4.17.21",
         "mute-stream": "0.0.8",
@@ -24547,21 +24592,6 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/brc-dd"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/is-builtin-module": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
-      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
-      "dev": true,
-      "dependencies": {
-        "builtin-modules": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/netlify-cli/node_modules/is-core-module": {
@@ -25045,6 +25075,18 @@
         "node": ">=14"
       }
     },
+    "node_modules/netlify-cli/node_modules/lambda-local/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/netlify-cli/node_modules/latest-version": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-9.0.0.tgz",
@@ -25213,18 +25255,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
-    "node_modules/netlify-cli/node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "dev": true
-    },
-    "node_modules/netlify-cli/node_modules/lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true
     },
     "node_modules/netlify-cli/node_modules/lodash.deburr": {
@@ -25503,12 +25533,12 @@
       }
     },
     "node_modules/netlify-cli/node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/netlify-cli/node_modules/make-dir": {
@@ -25656,12 +25686,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/netlify-cli/node_modules/micro-api-client": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/micro-api-client/-/micro-api-client-3.3.0.tgz",
-      "integrity": "sha512-y0y6CUB9RLVsy3kfgayU28746QrNMpSm9O/AYGNsBgOkJr/X/Jk0VLGoO8Ude7Bpa8adywzF+MzXNZRFRsNPhg==",
-      "dev": true
     },
     "node_modules/netlify-cli/node_modules/micro-memoize": {
       "version": "4.1.3",
@@ -26004,9 +26028,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/node-fetch-native": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.6.tgz",
-      "integrity": "sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "dev": true
     },
     "node_modules/netlify-cli/node_modules/node-forge": {
@@ -26030,9 +26054,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/node-mock-http": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.0.tgz",
-      "integrity": "sha512-0uGYQ1WQL1M5kKvGRXWQ3uZCHtLTO8hln3oBjIusM75WoesZ909uQJs/Hb946i2SS+Gsrhkaa6iAO17jRIv6DQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.3.tgz",
+      "integrity": "sha512-jN8dK25fsfnMrVsEhluUTPkBFY+6ybu7jSB1n+ri/vOGjJxU8J9CZhpSGkHXSkFjtUhbmoncG/YG9ta5Ludqog==",
       "dev": true
     },
     "node_modules/netlify-cli/node_modules/node-source-walk": {
@@ -26262,15 +26286,15 @@
       }
     },
     "node_modules/netlify-cli/node_modules/open": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.1.2.tgz",
-      "integrity": "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
       "dev": true,
       "dependencies": {
         "default-browser": "^5.2.1",
         "define-lazy-prop": "^3.0.0",
         "is-inside-container": "^1.0.0",
-        "is-wsl": "^3.1.0"
+        "wsl-utils": "^0.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -26293,15 +26317,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/netlify-cli/node_modules/p-cancelable": {
@@ -26338,27 +26353,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/p-every": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-every/-/p-every-2.0.0.tgz",
-      "integrity": "sha512-MCz9DqD5opPC48Zsd+BHm56O/HfhYIQQtupfDzhXoVgQdg/Ux4F8/JcdRuQ+arq7zD5fB6zP3axbH3d9Nr8dlw==",
-      "dev": true,
-      "dependencies": {
-        "p-map": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/p-every/node_modules/p-map": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/netlify-cli/node_modules/p-filter": {
@@ -26685,6 +26679,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/netlify-cli/node_modules/picoquery": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/picoquery/-/picoquery-2.5.0.tgz",
+      "integrity": "sha512-j1kgOFxtaCyoFCkpoYG2Oj3OdGakadO7HZ7o5CqyRazlmBekKhbDoUnNnXASE07xSY4nDImWZkrZv7toSxMi/g==",
+      "dev": true
     },
     "node_modules/netlify-cli/node_modules/pino": {
       "version": "9.7.0",
@@ -27059,18 +27059,18 @@
       }
     },
     "node_modules/netlify-cli/node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
       "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
+        "iconv-lite": "0.7.0",
         "unpipe": "1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
     "node_modules/netlify-cli/node_modules/raw-body/node_modules/depd": {
@@ -27099,15 +27099,19 @@
       }
     },
     "node_modules/netlify-cli/node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
       "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/netlify-cli/node_modules/rc": {
@@ -28550,9 +28554,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -28578,9 +28582,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/strip-ansi/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -28857,18 +28861,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/netlify-cli/node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
     "node_modules/netlify-cli/node_modules/tmp-promise": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
@@ -28879,10 +28871,11 @@
       }
     },
     "node_modules/netlify-cli/node_modules/tmp-promise/node_modules/tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.14"
       }
@@ -29092,11 +29085,10 @@
       "dev": true
     },
     "node_modules/netlify-cli/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "license": "MIT"
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
     },
     "node_modules/netlify-cli/node_modules/unicorn-magic": {
       "version": "0.1.0",
@@ -29165,17 +29157,17 @@
       }
     },
     "node_modules/netlify-cli/node_modules/unstorage": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.16.1.tgz",
-      "integrity": "sha512-gdpZ3guLDhz+zWIlYP1UwQ259tG5T5vYRzDaHMkQ1bBY1SQPutvZnrRjTFaWUUpseErJIgAZS51h6NOcZVZiqQ==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.1.tgz",
+      "integrity": "sha512-KKGwRTT0iVBCErKemkJCLs7JdxNVfqTPc/85ae1XES0+bsHbc/sFBfVi5kJp156cc51BHinIH2l3k0EZ24vOBQ==",
       "dev": true,
       "dependencies": {
         "anymatch": "^3.1.3",
         "chokidar": "^4.0.3",
         "destr": "^2.0.5",
-        "h3": "^1.15.3",
+        "h3": "^1.15.4",
         "lru-cache": "^10.4.3",
-        "node-fetch-native": "^1.6.6",
+        "node-fetch-native": "^1.6.7",
         "ofetch": "^1.4.1",
         "ufo": "^1.6.1"
       },
@@ -29192,6 +29184,7 @@
         "@planetscale/database": "^1.19.0",
         "@upstash/redis": "^1.34.3",
         "@vercel/blob": ">=0.27.1",
+        "@vercel/functions": "^2.2.12 || ^3.0.0",
         "@vercel/kv": "^1.0.1",
         "aws4fetch": "^1.0.20",
         "db0": ">=0.2.1",
@@ -29234,6 +29227,9 @@
           "optional": true
         },
         "@vercel/blob": {
+          "optional": true
+        },
+        "@vercel/functions": {
           "optional": true
         },
         "@vercel/kv": {
@@ -29934,6 +29930,21 @@
         }
       }
     },
+    "node_modules/netlify-cli/node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/netlify-cli/node_modules/xdg-basedir": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
@@ -30163,9 +30174,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -32406,6 +32417,55 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/primitives/packages/ai-gateway": {
+      "name": "@netlify/ai-gateway",
+      "version": "1.0.0",
+      "extraneous": true,
+      "dependencies": {
+        "@netlify/api": "^14.0.4"
+      },
+      "devDependencies": {
+        "@types/node": "20.14.15",
+        "npm-run-all2": "^7.0.2",
+        "tsup": "8.5.0",
+        "typescript": "5.5.4",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.6.1"
+      },
+      "peerDependencies": {
+        "@netlify/api": ">=14.0.0"
+      }
+    },
+    "node_modules/primitives/packages/dev": {
+      "name": "@netlify/dev",
+      "version": "4.5.9",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@netlify/blobs": "10.0.10",
+        "@netlify/config": "^23.2.0",
+        "@netlify/dev-utils": "4.1.3",
+        "@netlify/edge-functions": "2.17.4",
+        "@netlify/functions": "4.2.5",
+        "@netlify/headers": "2.0.11",
+        "@netlify/images": "1.2.7",
+        "@netlify/redirects": "3.0.12",
+        "@netlify/runtime": "4.0.15",
+        "@netlify/static": "3.0.10",
+        "ulid": "^3.0.0"
+      },
+      "devDependencies": {
+        "@netlify/api": "^14.0.4",
+        "@netlify/types": "2.0.3",
+        "tsup": "^8.0.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.6.1"
       }
     },
     "node_modules/prism-react-renderer": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "jimp": "^1.6.0",
     "js-yaml": "^4.1.0",
     "markdownlint-cli": "^0.45.0",
-    "netlify-cli": "^23.0.0",
+    "netlify-cli": "^23.7.3",
     "prettier": "^3.6.1",
     "rimraf": "^6.0.1",
     "typescript": "~5.8.3"
@@ -71,5 +71,8 @@
   },
   "engines": {
     "node": ">=18.0"
+  },
+  "overrides": {
+    "tmp": "0.2.4"
   }
 }


### PR DESCRIPTION
These changes address this dependabot issue: https://github.com/prismatic-io/embedded-workflow-builder-docs/security/dependabot/8

Unfortunately the newest version of `netlify-cli` still depends on the offending version of tmp, so for now I've added an override in our `package.json`. Once they resolve things on their side we can remove the override.